### PR TITLE
Cast the top_speakers list to a set to reduce search time

### DIFF
--- a/get_ts_posts.py
+++ b/get_ts_posts.py
@@ -31,6 +31,7 @@ def main():
         for line in handle:
             tline = line.strip().split('\t')[0]
             top_speakers.append(tline)
+    top_speakers = set(top_speakers)
 
     if opt.random:
         rfile = open('rposts', 'w')

--- a/merge_ts_posts.py
+++ b/merge_ts_posts.py
@@ -21,6 +21,7 @@ def main():
         for line in handle:
             tline = line.strip().split('\t')[0]
             top_speakers.append(tline)
+    top_speakers = set(top_speakers)
 
     all_posts = {ts: 0 for ts in top_speakers}
     for cur_dir in DIR_SET:


### PR DESCRIPTION
## Issue
The `get_ts_script.py` and `merge_ts_script.py` scripts take too long when processing a large number of authors in the list specified by the `top_speakers` variable. As a consequence, the average number of processed items per second is 150 items/s (on an Xeon CPU)

## Solution
Cast the `top_speakers` list to a set. As a consequence, increase the average number of processed items per second to 97,016 items/s (on Xeon CPU). This improvement is due to the difference in time complexity of the `in` operation—`List` is O(n) and `Set` is O(1) ([reference](https://wiki.python.org/moin/TimeComplexity)).
